### PR TITLE
nitpicks

### DIFF
--- a/components/ActionNetworkForm.vue
+++ b/components/ActionNetworkForm.vue
@@ -3,9 +3,9 @@
 
 <template>
   <div class="sml-push-y2 med-push-y3">
-    <div class="text-center">
+    <div>
       <div v-if="hasSigned">
-        <h2 class="text-success">{{ $t('thanks.title') }}</h2>
+        <h2 class="text-success text-center">{{ $t('thanks.title') }}</h2>
         <p class="sml-push-y1">{{ $t('thanks.share') }}</p>
         <div class="row sml-push-y2 med-push-y3">
           <div class="sml-c12 lrg-c6">

--- a/locales/pages/index.yml
+++ b/locales/pages/index.yml
@@ -19,10 +19,10 @@ en:
       <br>
       <strong>Want to Contribute?</strong>
       <br>
-      Select a cryptocurrency from the list below and
+      Select a cryptocurrency from the list below,
       copy the <a href="https://www.coinbase.com/" target="_blank">
         Coinbase</a>
-      address displayed.
+      address displayed and send it some crypto.
     </p>
   scroll_down: Contribute
   what_title: What’s happening?

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -142,7 +142,7 @@
     <section id="how" class="sml-pad-y3 med-pad-y6">
       <div class="wrapper">
         <div class="row">
-          <div class="sml-c12 lrg-c8 grid-center med-pad-y6">
+          <div class="sml-c12 lrg-c8 grid-center sml-pad-y2 med-pad-y6">
             <h2 class="text-center bold-color-text">
               {{ $t('how_title') }}
             </h2>


### PR DESCRIPTION
* change copy to specify you not only need to copy the coinbase address, you also need to send it some crypto
* added top padding on timeline on mobile 
* made the success text left-justified