### PR TITLE
move the logo cloud higher on the page and add a heading to the logos section

### DIFF
--- a/locales/pages/index.yml
+++ b/locales/pages/index.yml
@@ -99,6 +99,7 @@ en:
     If you want to receive email updates about the latest breaking news in the fight
     to defend crypto or want to find more ways to get involved, fill out the
     information below and let us know.
+  logos_title: Who’s Behind Defend Crypto
   how_title: How We Got Here
   how_description_html: |
     <p>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -123,6 +123,21 @@
       </div> <!-- -->
     </section>
 
+    <section id="logocloud">
+      <div class="wrapper">
+        <div class="row">
+          <div class="sml-c12 lrg-c8 sml-pad-y4 med-pad-y4 grid-center text-center">
+            <h2>{{ $t('logos_title') }}</h2>
+          </div> <!-- .c -->
+        </div> <!-- .row -->
+      </div> <!-- .wrapper -->
+      <div class="row">
+        <div class="sml-c12 med-c10 med-pad-y2 grid-center">
+          <LogoCloud />
+        </div> <!-- .c -->
+      </div> <!-- row -->
+    </section> <!-- logos -->
+
     <section id="contribute" class="sml-pad-y3">
       <div class="wrapper">
         <div class="row">
@@ -191,14 +206,6 @@
         </div> <!-- .row -->
       </div> <!-- .wrapper -->
     </section>
-
-    <section id="logocloud">
-      <div class="row">
-        <div class="sml-c12 med-c10 med-pad-y2 grid-center">
-          <LogoCloud />
-        </div> <!-- .c -->
-      </div> <!-- row -->
-    </section> <!-- logos -->
   </DefaultLayout>
 </template>
 


### PR DESCRIPTION
Desktop:

<img width="1440" alt="Screen Shot 2019-05-28 at 7 45 38 AM" src="https://user-images.githubusercontent.com/4806817/58451606-cf63c380-811c-11e9-974a-f7563f37963f.png">

Mobile:

<img width="397" alt="Screen Shot 2019-05-28 at 7 45 26 AM" src="https://user-images.githubusercontent.com/4806817/58451609-d4287780-811c-11e9-960c-f52a575bd111.png">
